### PR TITLE
Fixed the 'external_value' label and disabled clearing the belief map

### DIFF
--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -527,6 +527,7 @@ void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
             newLabeling.addLabel("cutoff");
             newLabeling.addLabel("clipping");
             newLabeling.addLabel("finite_mem");
+            newLabeling.addLabel("external_value");
 
             auto transMatrix = scheduledModel->getTransitionMatrix();
             for (uint64_t i = 0; i < scheduledModel->getNumberOfStates(); ++i) {
@@ -636,6 +637,7 @@ void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
                     newLabeling.addLabel("cutoff");
                     newLabeling.addLabel("clipping");
                     newLabeling.addLabel("finite_mem");
+                    newLabeling.addLabel("external_value");
 
                     auto transMatrix = scheduledModel->getTransitionMatrix();
                     for (uint64_t i = 0; i < scheduledModel->getNumberOfStates(); ++i) {
@@ -1104,7 +1106,7 @@ bool BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefM
             stateStored = true;
             if (unfoldingControl == UnfoldingControl::PauseAndComputeCutoffValues) {
                 beliefExchange.idToBeliefMap = underApproximation->getBeliefIdToBeliefMap(underApproximation->getBeliefIdsOfStatesToExplore());
-                beliefExchange.beliefIdToValueMap.clear();
+                //beliefExchange.beliefIdToValueMap.clear();
                 setUnfoldingToWait();
                 while (unfoldingControl == UnfoldingControl::WaitForCutoffValues)
                     ;


### PR DESCRIPTION
With these changes, the new communication has the expected behaviour. Not sure if clearing the belief map had any purpose?