### PR TITLE
Added checks for empty finite memory scheduler values

### DIFF
--- a/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
@@ -905,7 +905,10 @@ BeliefMdpExplorer<PomdpType, BeliefValueType>::computeFMSchedulerValueForMemoryN
     STORM_LOG_ASSERT(!fmSchedulerValueList.empty(), "Requested finite memory scheduler value bounds but none were available.");
     STORM_LOG_ASSERT(index < fmSchedulerValueList.size(), "Requested finite memory scheduler value bounds for index " << index << "not available.");
     auto obs = beliefManager->getBeliefObservation(beliefId);
-    STORM_LOG_ASSERT(fmSchedulerValueList.size() > obs, "Requested value bound for observation " << obs << " not available.");
+    if (fmSchedulerValueList.at(index).empty()) {
+        return {false, 0};
+    }
+    STORM_LOG_ASSERT(fmSchedulerValueList.at(index).size() > obs, "Requested value bound for observation " << obs << " not available.");
     STORM_LOG_ASSERT(fmSchedulerValueList.at(index).at(obs).size() > memoryNode,
                      "Requested value bound for observation " << obs << " and memory node " << memoryNode << " not available.");
     return beliefManager->getWeightedSum(beliefId, fmSchedulerValueList.at(index).at(obs).at(memoryNode));
@@ -1344,6 +1347,9 @@ uint64_t BeliefMdpExplorer<PomdpType, BeliefValueType>::addFMSchedValueList(std:
 
 template<typename PomdpType, typename BeliefValueType>
 uint64_t BeliefMdpExplorer<PomdpType, BeliefValueType>::getNrOfMemoryNodesForObservation(uint64_t index, uint32_t observation) const {
+    if (fmSchedulerValueList.at(index).empty()) {
+        return 0;
+    }
     return fmSchedulerValueList.at(index).at(observation).size();
 }
 


### PR DESCRIPTION
Sometimes it can happen that for certain beliefs we fail to compute an FSC in a given time limit, however, I must reserve the index in the fmSchedulerValueList for this belief in advance therefore in this case the FSC values will be empty. The old code would throw an exception in this case.

Also I think one assert in 'computeFMSchedulerValueForMemoryNode' was wrong so I fixed that.

Not sure this adheres to the coding style in Storm so feel free to adjust it.